### PR TITLE
Revert "Support ISO 8601 style date and time seperator"

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -351,9 +351,7 @@ func ParseTimestamp(currentLocation *time.Location, str string) (time.Time, erro
 
 	var hour, minute, second int
 	if len(str) > monSep+len("01-01")+1 {
-		if c := str[timeSep]; c != ' ' && c != 'T' && c != 't' {
-			return time.Time{}, fmt.Errorf("expected ' ' or 'T' at position %v; got %v", timeSep, c)
-		}
+		p.expect(str, " ", timeSep)
 		minSep := timeSep + 3
 		p.expect(str, ":", minSep)
 		hour = p.mustAtoi(str, timeSep+1, minSep)

--- a/encode_test.go
+++ b/encode_test.go
@@ -38,8 +38,6 @@ var timeTests = []struct {
 	{"22001-02-03", time.Date(22001, time.February, 3, 0, 0, 0, 0, time.FixedZone("", 0))},
 	{"2001-02-03", time.Date(2001, time.February, 3, 0, 0, 0, 0, time.FixedZone("", 0))},
 	{"2001-02-03 04:05:06", time.Date(2001, time.February, 3, 4, 5, 6, 0, time.FixedZone("", 0))},
-	{"2001-02-03T04:05:06", time.Date(2001, time.February, 3, 4, 5, 6, 0, time.FixedZone("", 0))},
-	{"2001-02-03t04:05:06", time.Date(2001, time.February, 3, 4, 5, 6, 0, time.FixedZone("", 0))},
 	{"2001-02-03 04:05:06.000001", time.Date(2001, time.February, 3, 4, 5, 6, 1000, time.FixedZone("", 0))},
 	{"2001-02-03 04:05:06.00001", time.Date(2001, time.February, 3, 4, 5, 6, 10000, time.FixedZone("", 0))},
 	{"2001-02-03 04:05:06.0001", time.Date(2001, time.February, 3, 4, 5, 6, 100000, time.FixedZone("", 0))},
@@ -98,7 +96,6 @@ var timeErrorTests = []string{
 	"2001-02-03 04:05:",
 	"2001-02-03 04:05:6",
 	"2001-02-03 04:05:06.123 B",
-	"2001-02-03S04:05:06",
 }
 
 // Test that parsing the string results in an error.


### PR DESCRIPTION
Reverts cockroachdb/pq#6

Obseleted by https://github.com/cockroachdb/cockroach/pull/5877.
