### PR TITLE
Don't register the driver under the "postgres" name by default

### DIFF
--- a/conditional_register.go
+++ b/conditional_register.go
@@ -1,0 +1,16 @@
+// +build register_crdb
+
+// andrei: Unconditional registration of the pq driver under the name "postgres"
+// was remove from conn.go and added to this conditionally-built file in order
+// to support linking this forked lib/pq with an unforked one. Users of the
+// forked lib don't need to use it through Go's sql package, so they don't need
+// this registration. pq's own tests do, however, so they must be built with
+// this build tag.
+
+package pq
+
+import "database/sql"
+
+func init() {
+	sql.Register("postgres", &drv{})
+}

--- a/conn.go
+++ b/conn.go
@@ -5,7 +5,6 @@ import (
 	"crypto/md5"
 	"crypto/tls"
 	"crypto/x509"
-	"database/sql"
 	"database/sql/driver"
 	"encoding/binary"
 	"errors"
@@ -43,10 +42,6 @@ type drv struct{}
 
 func (d *drv) Open(name string) (driver.Conn, error) {
 	return Open(name)
-}
-
-func init() {
-	sql.Register("postgres", &drv{})
 }
 
 type parameterStatus struct {


### PR DESCRIPTION
To allow this forked lib/pq to be linked along the original.
